### PR TITLE
Changes for camel-example-hibernate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ atlassian-ide-plugin.xml
 **/target/*
 **/.gitignore
 .gitignore
+
+examples/camel-example-hibernate/derby.log

--- a/components/camel-hibernate/pom.xml
+++ b/components/camel-hibernate/pom.xml
@@ -35,6 +35,10 @@
   <description>Camel Hibernate support</description>
 
   <properties>
+    <camel-version>2.17.2</camel-version>
+    <spring-version>4.3.1.RELEASE</spring-version>
+    <hibernate-version>5.2.1.Final</hibernate-version>
+
     <camel.osgi.export.pkg>org.apacheextras.camel.component.hibernate</camel.osgi.export.pkg>
     <camel.osgi.export.service>org.apache.camel.spi.ComponentResolver;component=hibernate</camel.osgi.export.service>
   </properties>
@@ -66,16 +70,19 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-orm</artifactId>
+      <version>${spring-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
+      <version>${spring-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
+      <version>10.12.1.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -86,6 +93,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/components/camel-hibernate/src/test/java/org/apacheextras/camel/component/hibernate/QueryBuilderHibernateTest.java
+++ b/components/camel-hibernate/src/test/java/org/apacheextras/camel/component/hibernate/QueryBuilderHibernateTest.java
@@ -30,7 +30,7 @@ import org.hibernate.SessionFactory;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
 import org.hibernate.service.ServiceRegistry;
-import org.hibernate.service.ServiceRegistryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,7 +53,7 @@ public class QueryBuilderHibernateTest {
         Configuration configuration = new Configuration().setProperty(Environment.DIALECT, "org.hibernate.dialect.DerbyDialect")
             .setProperty(Environment.URL, "jdbc:derby:target/testdb;create=true").setProperty(Environment.USER, "").setProperty(Environment.PASS, "")
             .setProperty(Environment.HBM2DDL_AUTO, "create").addResource("org/apacheextras/camel/examples/SendEmail.hbm.xml");
-        ServiceRegistry serviceRegistry = new ServiceRegistryBuilder().applySettings(configuration.getProperties()).buildServiceRegistry();
+        ServiceRegistry serviceRegistry = new StandardServiceRegistryBuilder().applySettings(configuration.getProperties()).build();
         SessionFactory sessionFactory = configuration.buildSessionFactory(serviceRegistry);
         session = sessionFactory.openSession();
 

--- a/components/camel-hibernate/src/test/resources/org/apacheextras/camel/component/hibernate/HibernateSpringTest-context.xml
+++ b/components/camel-hibernate/src/test/resources/org/apacheextras/camel/component/hibernate/HibernateSpringTest-context.xml
@@ -48,7 +48,7 @@
         <constructor-arg ref="transactionTemplate"/>
     </bean>
 
-  <bean id="sessionFactory" class="org.springframework.orm.hibernate4.LocalSessionFactoryBean">
+  <bean id="sessionFactory" class="org.springframework.orm.hibernate5.LocalSessionFactoryBean">
     <property name="dataSource" ref="dataSource"/>
     <property name="mappingResources">
       <list>
@@ -65,7 +65,7 @@
 
   <jdbc:embedded-database id="dataSource" type="DERBY" />
 
-  <bean id="transactionManager" class="org.springframework.orm.hibernate4.HibernateTransactionManager">
+  <bean id="transactionManager" class="org.springframework.orm.hibernate5.HibernateTransactionManager">
     <property name="sessionFactory" ref="sessionFactory"/>
   </bean>
 

--- a/examples/camel-example-hibernate/pom.xml
+++ b/examples/camel-example-hibernate/pom.xml
@@ -34,6 +34,12 @@
 
   <name>Camel Extra :: Component Examples :: A Camel Hibernate Demo</name>
 
+  <properties>
+    <camel-version>2.17.2</camel-version>
+    <spring-version>4.3.1.RELEASE</spring-version>
+    <hibernate-version>5.2.1.Final</hibernate-version>
+  </properties>
+
   <dependencies>
 
     <!-- Camel components -->
@@ -57,15 +63,35 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-tx</artifactId>
     </dependency>
+    <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-jdbc</artifactId>
+    </dependency>
 
     <!-- jdbc -->
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
+      <version>10.12.1.1</version>
     </dependency>
     <dependency>
       <groupId>commons-dbcp</groupId>
       <artifactId>commons-dbcp</artifactId>
+      <version>1.4</version>
+    </dependency>
+
+    <!-- Hibernate framework -->
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core</artifactId>
+      <version>${hibernate-version}</version>
+    </dependency>
+
+    <!-- MySQL database driver -->
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>5.1.39</version>
     </dependency>
 
     <!-- logging -->

--- a/examples/camel-example-hibernate/src/main/resources/META-INF/spring/camel-context.xml
+++ b/examples/camel-example-hibernate/src/main/resources/META-INF/spring/camel-context.xml
@@ -42,9 +42,9 @@
 
   <camelContext xmlns="http://camel.apache.org/schema/spring">
 
-    <!-- route that generate new orders and insert them in the database -->
+    <!-- route that generates a new order every second and inserts it in the database -->
     <route id="generateOrder-route">
-      <from uri="timer:foo?period=5s"/>
+      <from uri="timer:foo?period=1s"/>
       <transform>
         <method ref="orderBean" method="generateOrder"/>
       </transform>
@@ -53,10 +53,16 @@
     </route>
 
 
-    <!-- route that process the orders by picking up new rows from the database
+    <!-- route that process the orders every 5 seconds by picking up new rows from the database
          and when done processing then update the row to mark it as processed -->
+    <!-- But, no... not really. It actually pulls the rows from the database and deletes them.
+          We definitely need something different to mark the row and leave it in the database. -->
+    <!-- Add "consumeDelete=false" to the uri tells camel to leave the row in the database.
+          But, still need something different to mark the row as processed.
+          It looks like that will require changing the "processOrder()" function to add an "@Consumed"
+          annotation, plus code to change the database row. -->
     <route id="processOrder-route">
-      <from uri="hibernate:org.apacheextras.camel.examples.hibernate.Order?delay=1s"/>
+      <from uri="hibernate:org.apacheextras.camel.examples.hibernate.Order?initialDelay=10s&amp;delay=5s"/>
       <to uri="bean:orderBean?method=processOrder"/>
       <log message="${body}"/>
     </route>
@@ -74,7 +80,8 @@
     <constructor-arg ref="sessionFactory"/>
     <constructor-arg ref="transactionTemplate"/>
   </bean>
-  <bean id="transactionManager" class="org.springframework.orm.hibernate4.HibernateTransactionManager">
+
+  <bean id="transactionManager" class="org.springframework.orm.hibernate5.HibernateTransactionManager">
     <property name="sessionFactory" ref="sessionFactory"/>
   </bean>
   <bean id="transactionTemplate" class="org.springframework.transaction.support.TransactionTemplate">
@@ -82,7 +89,7 @@
   </bean>
 
   <!-- setup Hibernate session factory -->
-  <bean id="sessionFactory" class="org.springframework.orm.hibernate4.LocalSessionFactoryBean">
+  <bean id="sessionFactory" class="org.springframework.orm.hibernate5.LocalSessionFactoryBean">
     <property name="dataSource" ref="dataSource"/>
     <!-- here we define the hibernate mapping files we use -->
     <property name="mappingResources">

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,8 @@
 
   <properties>
     <camel-version>2.17.2</camel-version>
+    <spring-version>4.3.1.RELEASE</spring-version>
+    <hibernate-version>5.2.1.Final</hibernate-version>
 
     <site-repo-url>scpexe://people.apache.org/www/activemq.apache.org/camel/maven/</site-repo-url>
     <sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/
@@ -83,7 +85,7 @@
     <esper-version>5.2.0</esper-version>
     <exist-version>0.9.2</exist-version>
     <geronimo-servlet-spec12-version>1.2</geronimo-servlet-spec12-version>
-    <hibernate-commons-annotation-version>4.0.2.Final</hibernate-commons-annotation-version>
+    <hibernate-commons-annotation-version>5.0.1.Final</hibernate-commons-annotation-version>
     <jandex-version>1.1.0.Final</jandex-version>
     <javax-validation-api-version>1.1.0.Final</javax-validation-api-version>
     <javassist-version>3.18.1-GA</javassist-version>
@@ -161,6 +163,18 @@
         <enabled>false</enabled>
       </snapshots>
     </repository-->
+
+    <!-- add the Maven Central Repository -->
+    <repository>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>http://repo.maven.apache.org/maven2</url>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+
     <repository>
       <id>neo4j.releases.repo</id>
       <url>http://m2.neo4j.org/content/repositories/releases/</url>
@@ -182,6 +196,21 @@
         <enabled>false</enabled>
       </releases>
     </pluginRepository>
+
+    <!-- Add the Maven Central Repository -->
+    <pluginRepository>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>http://repo.maven.apache.org/maven2</url>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <releases>
+        <updatePolicy>never</updatePolicy>
+      </releases>
+    </pluginRepository>
+
     <pluginRepository>
       <id>codehaus.repo</id>
       <name>Codehaus Repository</name>


### PR DESCRIPTION
Running the camel-example-hibernate example on our firewall-protected network required updating several dependencies. In particular, it needed Hibernate 5.2.1 and Spring 4.3.1. The old pom.xml files did not seem to find the hibernate-version and spring-version properties when set at the top level of camel-extra, so I added them to the components/pom.xml and examples/pom.xml files.

There is still a problem in the hibernate example, though. The original comment said that it pulled only new rows from the database and then marked them as processed. This doesn't happen. Instead, it deletes the rows as they are consumed. I'm still trying to figure out how to mark the rows and leave them in the table.

-Thom
OBTW, this is my first foray into maven and github land. So, please be gentle. ;)
