### PR TITLE
pom switch to camel 2.18.0-SNAPSHOT

### DIFF
--- a/components/camel-cics/pom.xml
+++ b/components/camel-cics/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>components</artifactId>
-    <version>2.17.2-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-cics</artifactId>

--- a/components/camel-couchbase/pom.xml
+++ b/components/camel-couchbase/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>components</artifactId>
-    <version>2.17.2-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-couchbase</artifactId>

--- a/components/camel-db4o/pom.xml
+++ b/components/camel-db4o/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache-extras.camel-extra</groupId>
         <artifactId>components</artifactId>
-        <version>2.17.2-SNAPSHOT</version>
+        <version>2.18.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-db4o</artifactId>

--- a/components/camel-esper/pom.xml
+++ b/components/camel-esper/pom.xml
@@ -26,7 +26,7 @@
   <parent>
       <groupId>org.apache-extras.camel-extra</groupId>
       <artifactId>components</artifactId>
-      <version>2.17.2-SNAPSHOT</version>
+      <version>2.18.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-esper</artifactId>

--- a/components/camel-exist/pom.xml
+++ b/components/camel-exist/pom.xml
@@ -26,7 +26,7 @@
   <parent>
       <groupId>org.apache-extras.camel-extra</groupId>
       <artifactId>components</artifactId>
-      <version>2.17.2-SNAPSHOT</version>
+      <version>2.18.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-exist</artifactId>

--- a/components/camel-hibernate/pom.xml
+++ b/components/camel-hibernate/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>components</artifactId>
-    <version>2.17.2-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-hibernate</artifactId>

--- a/components/camel-jboss/pom.xml
+++ b/components/camel-jboss/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache-extras.camel-extra</groupId>
         <artifactId>components</artifactId>
-        <version>2.17.2-SNAPSHOT</version>
+        <version>2.18.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-jboss</artifactId>

--- a/components/camel-jboss6/pom.xml
+++ b/components/camel-jboss6/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache-extras.camel-extra</groupId>
         <artifactId>components</artifactId>
-        <version>2.17.2-SNAPSHOT</version>
+        <version>2.18.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-jboss6</artifactId>

--- a/components/camel-jcifs/pom.xml
+++ b/components/camel-jcifs/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache-extras.camel-extra</groupId>
         <artifactId>components</artifactId>
-      <version>2.17.2-SNAPSHOT</version>
+      <version>2.18.0-SNAPSHOT</version>
     </parent>
 
    <artifactId>camel-jcifs</artifactId>

--- a/components/camel-rcode/pom.xml
+++ b/components/camel-rcode/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>components</artifactId>
-    <version>2.17.2-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-rcode</artifactId>

--- a/components/camel-spring-neo4j/pom.xml
+++ b/components/camel-spring-neo4j/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>components</artifactId>
-    <version>2.17.2-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-spring-neo4j</artifactId>

--- a/components/camel-virtualbox/pom.xml
+++ b/components/camel-virtualbox/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>components</artifactId>
-    <version>2.17.2-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-virtualbox</artifactId>

--- a/components/camel-vtdxml/pom.xml
+++ b/components/camel-vtdxml/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>components</artifactId>
-    <version>2.17.2-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-vtdxml</artifactId>

--- a/components/camel-wmq/pom.xml
+++ b/components/camel-wmq/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache-extras.camel-extra</groupId>
         <artifactId>components</artifactId>
-        <version>2.17.2-SNAPSHOT</version>
+        <version>2.18.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-wmq</artifactId>

--- a/components/camel-zeromq/pom.xml
+++ b/components/camel-zeromq/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>components</artifactId>
-    <version>2.17.2-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-zeromq</artifactId>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>camel-parent</artifactId>
-    <version>2.17.2-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/examples/camel-example-cics/pom.xml
+++ b/examples/camel-example-cics/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>examples</artifactId>
-    <version>2.17.2-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-example-cics</artifactId>

--- a/examples/camel-example-esper/pom.xml
+++ b/examples/camel-example-esper/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>examples</artifactId>
-    <version>2.17.2-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-esper-demo</artifactId>

--- a/examples/camel-example-hibernate/pom.xml
+++ b/examples/camel-example-hibernate/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>examples</artifactId>
-    <version>2.17.2-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-example-hibernate</artifactId>

--- a/examples/camel-example-rcode/pom.xml
+++ b/examples/camel-example-rcode/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>examples</artifactId>
-    <version>2.17.2-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-example-rcode</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -26,7 +26,7 @@
   <parent>
       <groupId>org.apache-extras.camel-extra</groupId>
       <artifactId>camel-parent</artifactId>
-      <version>2.17.2-SNAPSHOT</version>
+      <version>2.18.0-SNAPSHOT</version>
       <relativePath>..</relativePath>
   </parent>
 

--- a/platform/karaf/features/pom.xml
+++ b/platform/karaf/features/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>features</artifactId>
-    <version>2.17.2-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache-extras.camel-extra.karaf</groupId>

--- a/platform/karaf/pom.xml
+++ b/platform/karaf/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>platform</artifactId>
-    <version>2.17.2-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>features</artifactId>

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>camel-parent</artifactId>
-    <version>2.17.2-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,12 +27,12 @@
   <parent>
     <groupId>org.apache.camel</groupId>
     <artifactId>camel-parent</artifactId>
-    <version>2.17.2</version>
+    <version>2.18.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache-extras.camel-extra</groupId>
   <artifactId>camel-parent</artifactId>
-  <version>2.17.2-SNAPSHOT</version>
+  <version>2.18.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Camel Extra</name>
   <description>Camel Extra Parent POM</description>

--- a/tests/camel-extra-itest-karaf/pom.xml
+++ b/tests/camel-extra-itest-karaf/pom.xml
@@ -26,7 +26,7 @@ http://www.gnu.org/licenses/gpl-2.0-standalone.html
   <parent>
     <artifactId>tests</artifactId>
     <groupId>org.apache-extras.camel-extra</groupId>
-    <version>2.17.2-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -26,7 +26,7 @@ http://www.gnu.org/licenses/gpl-2.0-standalone.html
   <parent>
     <artifactId>camel-parent</artifactId>
     <groupId>org.apache-extras.camel-extra</groupId>
-    <version>2.17.2-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Upgrade maven reference to 2.18.0-SNAPSHOT

Can it merge with official release (coming soon)
