### PR TITLE
CAMEX-72 - readLock=change (camel-extra-2.15.x)

### DIFF
--- a/components/camel-jcifs/src/main/java/org/apacheextras/camel/component/jcifs/strategy/SmbChangedExclusiveReadLockStrategy.java
+++ b/components/camel-jcifs/src/main/java/org/apacheextras/camel/component/jcifs/strategy/SmbChangedExclusiveReadLockStrategy.java
@@ -1,0 +1,186 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apacheextras.camel.component.jcifs.strategy;
+
+import java.util.Date;
+import java.util.List;
+
+import jcifs.smb.SmbFile;
+import org.apache.camel.Exchange;
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.component.file.GenericFile;
+import org.apache.camel.component.file.GenericFileEndpoint;
+import org.apache.camel.component.file.GenericFileExclusiveReadLockStrategy;
+import org.apache.camel.component.file.GenericFileOperations;
+import org.apache.camel.util.CamelLogger;
+import org.apache.camel.util.StopWatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @see org.apache.camel.component.file.remote.strategy.SftpChangedExclusiveReadLockStrategy
+ */
+public class SmbChangedExclusiveReadLockStrategy implements GenericFileExclusiveReadLockStrategy<SmbFile> {
+    private static final Logger LOG = LoggerFactory.getLogger(SmbChangedExclusiveReadLockStrategy.class);
+    private long timeout;
+    private long checkInterval = 5000;
+    private LoggingLevel readLockLoggingLevel = LoggingLevel.WARN;
+    private long minLength = 1;
+    private long minAge;
+
+    @Override
+    public void prepareOnStartup(GenericFileOperations<SmbFile> tGenericFileOperations, GenericFileEndpoint<SmbFile> tGenericFileEndpoint) throws Exception {
+        // noop
+    }
+
+    public boolean acquireExclusiveReadLock(GenericFileOperations<SmbFile> operations, GenericFile<SmbFile> file, Exchange exchange) throws Exception {
+        boolean exclusive = false;
+
+        LOG.trace("Waiting for exclusive read lock to file: " + file);
+
+        long lastModified = Long.MIN_VALUE;
+        long length = Long.MIN_VALUE;
+        StopWatch watch = new StopWatch();
+        long startTime = (new Date()).getTime();
+
+        while (!exclusive) {
+            // timeout check
+            if (timeout > 0) {
+                long delta = watch.taken();
+                if (delta > timeout) {
+                    CamelLogger.log(LOG, readLockLoggingLevel,
+                            "Cannot acquire read lock within " + timeout + " millis. Will skip the file: " + file);
+                    // we could not get the lock within the timeout period, so return false
+                    return false;
+                }
+            }
+
+            long newLastModified = 0;
+            long newLength = 0;
+
+            LOG.trace("Using full directory listing to update file information for {}.", file);
+            // fast option not available (smb listFiles only handles directories), so list the directory and filter the file name
+            List<SmbFile> files = operations.listFiles(file.getParent());
+
+            LOG.trace("List files {} found {} files", file.getAbsoluteFilePath(), files.size());
+            for (SmbFile f : files) {
+                // use same attribute sources as org.apacheextras.camel.component.jcifs.SmbConsumer#asGenericFile()
+                if (f.getName().equals(file.getFileNameOnly())) {
+                    newLastModified = f.getLastModified();
+                    newLength = f.getContentLength();
+                }
+            }
+
+            LOG.trace("Previous last modified: " + lastModified + ", new last modified: " + newLastModified);
+            LOG.trace("Previous length: " + length + ", new length: " + newLength);
+            long newOlderThan = startTime + watch.taken() - minAge;
+            LOG.trace("New older than threshold: {}", newOlderThan);
+
+            if (newLength >= minLength && ((minAge == 0 && newLastModified == lastModified && newLength == length) || (minAge != 0 && newLastModified < newOlderThan))) {
+                LOG.trace("Read lock acquired.");
+                exclusive = true;
+            } else {
+                // set new base file change information
+                lastModified = newLastModified;
+                length = newLength;
+
+                boolean interrupted = sleep();
+                if (interrupted) {
+                    // we were interrupted while sleeping, we are likely being shutdown so return false
+                    return false;
+                }
+            }
+        }
+
+        return exclusive;
+    }
+
+    private boolean sleep() {
+        LOG.trace("Exclusive read lock not granted. Sleeping for " + checkInterval + " millis.");
+        try {
+            Thread.sleep(checkInterval);
+            return false;
+        } catch (InterruptedException e) {
+            LOG.debug("Sleep interrupted while waiting for exclusive read lock, so breaking out");
+            return true;
+        }
+    }
+
+    @Override
+    public void releaseExclusiveReadLockOnAbort(GenericFileOperations<SmbFile> operations, GenericFile<SmbFile> file, Exchange exchange) throws Exception {
+        // noop
+    }
+
+    @Override
+    public void releaseExclusiveReadLockOnRollback(GenericFileOperations<SmbFile> operations, GenericFile<SmbFile> file, Exchange exchange) throws Exception {
+        // noop
+    }
+
+    @Override
+    public void releaseExclusiveReadLockOnCommit(GenericFileOperations<SmbFile> operations, GenericFile<SmbFile> file, Exchange exchange) throws Exception {
+        // noop
+    }
+
+    public long getTimeout() {
+        return timeout;
+    }
+
+    @Override
+    public void setTimeout(long timeout) {
+        this.timeout = timeout;
+    }
+
+    public long getCheckInterval() {
+        return checkInterval;
+    }
+
+    @Override
+    public void setCheckInterval(long checkInterval) {
+        this.checkInterval = checkInterval;
+    }
+
+    @Override
+    public void setReadLockLoggingLevel(LoggingLevel readLockLoggingLevel) {
+        this.readLockLoggingLevel = readLockLoggingLevel;
+    }
+
+    public long getMinLength() {
+        return minLength;
+    }
+
+    public void setMinLength(long minLength) {
+        this.minLength = minLength;
+    }
+
+    public long getMinAge() {
+        return minAge;
+    }
+
+    public void setMinAge(long minAge) {
+        this.minAge = minAge;
+    }
+
+    @Override
+    public void setMarkerFiler(boolean markerFiler) {
+        // noop - not supported by smb
+    }
+
+    @Override
+    public void setDeleteOrphanLockFiles(boolean deleteOrphanLockFiles) {
+        // noop - not supported by smb
+    }
+}

--- a/components/camel-jcifs/src/main/java/org/apacheextras/camel/component/jcifs/strategy/SmbChangedExclusiveReadLockStrategy.java
+++ b/components/camel-jcifs/src/main/java/org/apacheextras/camel/component/jcifs/strategy/SmbChangedExclusiveReadLockStrategy.java
@@ -121,17 +121,7 @@ public class SmbChangedExclusiveReadLockStrategy implements GenericFileExclusive
     }
 
     @Override
-    public void releaseExclusiveReadLockOnAbort(GenericFileOperations<SmbFile> operations, GenericFile<SmbFile> file, Exchange exchange) throws Exception {
-        // noop
-    }
-
-    @Override
-    public void releaseExclusiveReadLockOnRollback(GenericFileOperations<SmbFile> operations, GenericFile<SmbFile> file, Exchange exchange) throws Exception {
-        // noop
-    }
-
-    @Override
-    public void releaseExclusiveReadLockOnCommit(GenericFileOperations<SmbFile> operations, GenericFile<SmbFile> file, Exchange exchange) throws Exception {
+    public void releaseExclusiveReadLock(GenericFileOperations<SmbFile> operations, GenericFile<SmbFile> file, Exchange exchange) throws Exception {
         // noop
     }
 
@@ -176,11 +166,6 @@ public class SmbChangedExclusiveReadLockStrategy implements GenericFileExclusive
 
     @Override
     public void setMarkerFiler(boolean markerFiler) {
-        // noop - not supported by smb
-    }
-
-    @Override
-    public void setDeleteOrphanLockFiles(boolean deleteOrphanLockFiles) {
         // noop - not supported by smb
     }
 }

--- a/components/camel-jcifs/src/main/java/org/apacheextras/camel/component/jcifs/strategy/SmbProcessStrategyFactory.java
+++ b/components/camel-jcifs/src/main/java/org/apacheextras/camel/component/jcifs/strategy/SmbProcessStrategyFactory.java
@@ -1,0 +1,143 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apacheextras.camel.component.jcifs.strategy;
+
+import java.util.Map;
+
+import jcifs.smb.SmbFile;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Expression;
+import org.apache.camel.component.file.GenericFileExclusiveReadLockStrategy;
+import org.apache.camel.component.file.GenericFileProcessStrategy;
+import org.apache.camel.component.file.strategy.GenericFileDeleteProcessStrategy;
+import org.apache.camel.component.file.strategy.GenericFileExpressionRenamer;
+import org.apache.camel.component.file.strategy.GenericFileNoOpProcessStrategy;
+import org.apache.camel.component.file.strategy.GenericFileRenameExclusiveReadLockStrategy;
+import org.apache.camel.component.file.strategy.GenericFileRenameProcessStrategy;
+import org.apache.camel.util.ObjectHelper;
+
+/**
+ * @see org.apache.camel.component.file.remote.strategy.SftpProcessStrategyFactory
+ */
+public final class SmbProcessStrategyFactory {
+
+    private SmbProcessStrategyFactory() {
+    }
+
+    public static GenericFileProcessStrategy<SmbFile> createGenericFileProcessStrategy(CamelContext context, Map<String, Object> params) {
+
+        // We assume a value is present only if its value not null for String and 'true' for boolean
+        Expression moveExpression = (Expression) params.get("move");
+        Expression moveFailedExpression = (Expression) params.get("moveFailed");
+        Expression preMoveExpression = (Expression) params.get("preMove");
+        boolean isNoop = params.get("noop") != null;
+        boolean isDelete = params.get("delete") != null;
+        boolean isMove = moveExpression != null || preMoveExpression != null || moveFailedExpression != null;
+
+        if (isDelete) {
+            GenericFileDeleteProcessStrategy<SmbFile> strategy = new GenericFileDeleteProcessStrategy<SmbFile>();
+            strategy.setExclusiveReadLockStrategy(getExclusiveReadLockStrategy(params));
+            if (preMoveExpression != null) {
+                GenericFileExpressionRenamer<SmbFile> renamer = new GenericFileExpressionRenamer<SmbFile>();
+                renamer.setExpression(preMoveExpression);
+                strategy.setBeginRenamer(renamer);
+            }
+            if (moveFailedExpression != null) {
+                GenericFileExpressionRenamer<SmbFile> renamer = new GenericFileExpressionRenamer<SmbFile>();
+                renamer.setExpression(moveFailedExpression);
+                strategy.setFailureRenamer(renamer);
+            }
+            return strategy;
+        } else if (isMove || isNoop) {
+            GenericFileRenameProcessStrategy<SmbFile> strategy = new GenericFileRenameProcessStrategy<SmbFile>();
+            strategy.setExclusiveReadLockStrategy(getExclusiveReadLockStrategy(params));
+            if (!isNoop && moveExpression != null) {
+                // move on commit is only possible if not noop
+                GenericFileExpressionRenamer<SmbFile> renamer = new GenericFileExpressionRenamer<SmbFile>();
+                renamer.setExpression(moveExpression);
+                strategy.setCommitRenamer(renamer);
+            }
+            // both move and noop supports pre move
+            if (moveFailedExpression != null) {
+                GenericFileExpressionRenamer<SmbFile> renamer = new GenericFileExpressionRenamer<SmbFile>();
+                renamer.setExpression(moveFailedExpression);
+                strategy.setFailureRenamer(renamer);
+            }
+            // both move and noop supports pre move
+            if (preMoveExpression != null) {
+                GenericFileExpressionRenamer<SmbFile> renamer = new GenericFileExpressionRenamer<SmbFile>();
+                renamer.setExpression(preMoveExpression);
+                strategy.setBeginRenamer(renamer);
+            }
+            return strategy;
+        } else {
+            // default strategy will do nothing
+            GenericFileNoOpProcessStrategy<SmbFile> strategy = new GenericFileNoOpProcessStrategy<SmbFile>();
+            strategy.setExclusiveReadLockStrategy(getExclusiveReadLockStrategy(params));
+            return strategy;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static GenericFileExclusiveReadLockStrategy<SmbFile> getExclusiveReadLockStrategy(Map<String, Object> params) {
+        GenericFileExclusiveReadLockStrategy<SmbFile> strategy = (GenericFileExclusiveReadLockStrategy<SmbFile>) params.get("exclusiveReadLockStrategy");
+        if (strategy != null) {
+            return strategy;
+        }
+
+        // no explicit strategy set then fallback to readLock option
+        String readLock = (String) params.get("readLock");
+        if (ObjectHelper.isNotEmpty(readLock)) {
+            if ("none".equals(readLock) || "false".equals(readLock)) {
+                return null;
+            } else if ("rename".equals(readLock)) {
+                GenericFileRenameExclusiveReadLockStrategy<SmbFile> readLockStrategy = new GenericFileRenameExclusiveReadLockStrategy<SmbFile>();
+                Long timeout = (Long) params.get("readLockTimeout");
+                if (timeout != null) {
+                    readLockStrategy.setTimeout(timeout);
+                }
+                Long checkInterval = (Long) params.get("readLockCheckInterval");
+                if (checkInterval != null) {
+                    readLockStrategy.setCheckInterval(checkInterval);
+                }
+                return readLockStrategy;
+            } else if ("changed".equals(readLock)) {
+                SmbChangedExclusiveReadLockStrategy readLockStrategy = new SmbChangedExclusiveReadLockStrategy();
+                Long timeout = (Long) params.get("readLockTimeout");
+                if (timeout != null) {
+                    readLockStrategy.setTimeout(timeout);
+                }
+                Long checkInterval = (Long) params.get("readLockCheckInterval");
+                if (checkInterval != null) {
+                    readLockStrategy.setCheckInterval(checkInterval);
+                }
+                Long minLength = (Long) params.get("readLockMinLength");
+                if (minLength != null) {
+                    readLockStrategy.setMinLength(minLength);
+                }
+                Long minAge = (Long) params.get("readLockMinAge");
+                if (null != minAge) {
+                    readLockStrategy.setMinAge(minAge);
+                }
+                return readLockStrategy;
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/components/camel-jcifs/src/main/resources/META-INF/services/org/apache/camel/component/smb
+++ b/components/camel-jcifs/src/main/resources/META-INF/services/org/apache/camel/component/smb
@@ -19,3 +19,4 @@
 # http://www.gnu.org/licenses/lgpl-3.0-standalone.html
 
 class=org.apacheextras.camel.component.jcifs.SmbComponent
+strategy.factory.class=org.apacheextras.camel.component.jcifs.strategy.SmbProcessStrategyFactory

--- a/components/camel-jcifs/src/test/java/org/apacheextras/camel/component/jcifs/FromSmbChangedReadLockTest.java
+++ b/components/camel-jcifs/src/test/java/org/apacheextras/camel/component/jcifs/FromSmbChangedReadLockTest.java
@@ -1,0 +1,124 @@
+/**************************************************************************************
+ https://camel-extra.github.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation; either version 3
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ 02110-1301, USA.
+
+ http://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ ***************************************************************************************/
+package org.apacheextras.camel.component.jcifs;
+
+import jcifs.smb.SmbFile;
+import jcifs.smb.SmbFileInputStream;
+import jcifs.smb.SmbFileOutputStream;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.easymock.EasyMock;
+import org.easymock.IAnswer;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+
+/**
+ * Unit test for readLock=changed
+ */
+public class FromSmbChangedReadLockTest extends BaseSmbTestSupport {
+    private static final byte[] FILE_CONTENT = "Hello World this file will appear to change".getBytes();
+
+    private SmbFile rootDir;
+    private SmbFile sourceFile;
+    private SmbFileInputStream mockInputStream;
+    private SmbFileOutputStream mockOutputStream;
+
+    @EndpointInject(uri = "mock:result")
+    private MockEndpoint mockResult;
+
+    protected String getSmbBaseUrl() {
+        return "smb://localhost/" + getShare() + "/camel/" + getClass().getSimpleName();
+    }
+
+    protected String getSmbUrl() {
+        return "smb://" + getDomain() + ";" + getUsername() + "@localhost/"
+                + getShare() + "/camel/" + getClass().getSimpleName()
+                + "?password=" + getPassword()
+                + "&consumer.delay=5000"
+                + "&readLock=changed&readLockCheckInterval=1000";
+    }
+
+    public void setUpFileSystem() throws Exception {
+        sourceFile = createMock(SmbFile.class);
+        rootDir = createMock(SmbFile.class);
+
+        mockOutputStream = createMock(SmbFileOutputStream.class);
+        mockInputStream = createMock(SmbFileInputStream.class);
+        long startTime = System.currentTimeMillis();
+
+        expect(rootDir.listFiles()).andReturn(new SmbFile[]{sourceFile}).anyTimes();
+
+        expect(sourceFile.isDirectory()).andReturn(false).anyTimes();
+        expect(sourceFile.getName()).andReturn("hello.txt").anyTimes();
+        expect(sourceFile.getContentLength()).andReturn(FILE_CONTENT.length).anyTimes();
+
+        for (int i = 0; i < 5; i++) {
+            expect(sourceFile.getLastModified()).andReturn(startTime++);
+        }
+        expect(sourceFile.getLastModified()).andReturn(startTime).anyTimes();
+        expect(sourceFile.getInputStream()).andReturn(mockInputStream).anyTimes();
+
+
+        expect(mockInputStream.available()).andReturn(FILE_CONTENT.length);
+        expect(mockInputStream.read((byte[]) anyObject())).andAnswer(new IAnswer<Integer>() {
+            public Integer answer() throws Throwable {
+                byte[] b = (byte[]) EasyMock.getCurrentArguments()[0];
+                System.arraycopy(FILE_CONTENT, 0, b, 0, FILE_CONTENT.length);
+                return FILE_CONTENT.length;
+            }
+        });
+        expect(mockInputStream.read((byte[]) anyObject())).andReturn(-1);
+        mockInputStream.close();
+
+        smbApiFactory.putSmbFiles(getSmbBaseUrl() + "/", rootDir);
+
+        smbApiFactory.putSmbFiles(getSmbBaseUrl() + "/hello.txt", sourceFile);
+        smbApiFactory.putSmbFileOutputStream("hello.txt", mockOutputStream);
+    }
+
+
+    @Test
+    public void testChangedReadLock() throws Exception {
+        replay(rootDir, sourceFile, mockInputStream, mockOutputStream);
+
+        mockResult.expectedMessageCount(1);
+        mockResult.expectedBodiesReceived("Hello World this file will appear to change");
+
+        assertMockEndpointsSatisfied();
+
+        verify(rootDir, sourceFile, mockInputStream, mockOutputStream);
+    }
+
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            public void configure() throws Exception {
+                from(getSmbUrl()).to("mock:result");
+            }
+        };
+    }
+}

--- a/components/camel-jcifs/src/test/java/org/apacheextras/camel/component/jcifs/FromSmbChangedReadLockZeroLengthTest.java
+++ b/components/camel-jcifs/src/test/java/org/apacheextras/camel/component/jcifs/FromSmbChangedReadLockZeroLengthTest.java
@@ -1,0 +1,121 @@
+/**************************************************************************************
+ https://camel-extra.github.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation; either version 3
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ 02110-1301, USA.
+
+ http://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ ***************************************************************************************/
+package org.apacheextras.camel.component.jcifs;
+
+import jcifs.smb.SmbFile;
+import jcifs.smb.SmbFileInputStream;
+import jcifs.smb.SmbFileOutputStream;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.easymock.EasyMock;
+import org.easymock.IAnswer;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+
+/**
+ * Unit test for readLock=changed&readLockMinLength=0
+ */
+public class FromSmbChangedReadLockZeroLengthTest extends BaseSmbTestSupport {
+    private static final byte[] FILE_CONTENT = new byte[0];
+
+    private SmbFile rootDir;
+    private SmbFile sourceFile;
+    private SmbFileInputStream mockInputStream;
+    private SmbFileOutputStream mockOutputStream;
+
+    @EndpointInject(uri = "mock:result")
+    private MockEndpoint mockResult;
+
+    protected String getSmbBaseUrl() {
+        return "smb://localhost/" + getShare() + "/camel/" + getClass().getSimpleName();
+    }
+
+    protected String getSmbUrl() {
+        return "smb://" + getDomain() + ";" + getUsername() + "@localhost/"
+                + getShare() + "/camel/" + getClass().getSimpleName()
+                + "?password=" + getPassword()
+                + "&consumer.delay=5000"
+                + "&readLock=changed&readLockCheckInterval=1000"
+                + "&readLockMinLength=0";
+    }
+
+    public void setUpFileSystem() throws Exception {
+        sourceFile = createMock(SmbFile.class);
+        rootDir = createMock(SmbFile.class);
+
+        mockOutputStream = createMock(SmbFileOutputStream.class);
+        mockInputStream = createMock(SmbFileInputStream.class);
+        long startTime = System.currentTimeMillis();
+
+        expect(rootDir.listFiles()).andReturn(new SmbFile[]{sourceFile}).anyTimes();
+
+        expect(sourceFile.isDirectory()).andReturn(false).anyTimes();
+        expect(sourceFile.getName()).andReturn("hello.txt").anyTimes();
+        expect(sourceFile.getContentLength()).andReturn(FILE_CONTENT.length).anyTimes();
+        expect(sourceFile.getLastModified()).andReturn(startTime).anyTimes();
+        expect(sourceFile.getInputStream()).andReturn(mockInputStream).anyTimes();
+
+
+        expect(mockInputStream.available()).andReturn(FILE_CONTENT.length);
+        expect(mockInputStream.read((byte[]) anyObject())).andAnswer(new IAnswer<Integer>() {
+            public Integer answer() throws Throwable {
+                byte[] b = (byte[]) EasyMock.getCurrentArguments()[0];
+                System.arraycopy(FILE_CONTENT, 0, b, 0, FILE_CONTENT.length);
+                return FILE_CONTENT.length;
+            }
+        });
+        expect(mockInputStream.read((byte[]) anyObject())).andReturn(-1);
+        mockInputStream.close();
+
+        smbApiFactory.putSmbFiles(getSmbBaseUrl() + "/", rootDir);
+
+        smbApiFactory.putSmbFiles(getSmbBaseUrl() + "/hello.txt", sourceFile);
+        smbApiFactory.putSmbFileOutputStream("hello.txt", mockOutputStream);
+    }
+
+
+    @Test
+    public void testChangedReadLock() throws Exception {
+        replay(rootDir, sourceFile, mockInputStream, mockOutputStream);
+
+        mockResult.expectedMessageCount(1);
+        mockResult.expectedBodiesReceived(FILE_CONTENT);
+
+        assertMockEndpointsSatisfied();
+
+        verify(rootDir, sourceFile, mockInputStream, mockOutputStream);
+    }
+
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            public void configure() throws Exception {
+                from(getSmbUrl()).to("mock:result");
+            }
+        };
+    }
+}


### PR DESCRIPTION
Essentially the same as the master (Camel 2.17.x) and camel-extra-2.16.x change, except there was a Camel API change after 2.15.x in GenericFileExclusiveReadLockStrategy
