### PR TITLE
added new feature mapBody

### DIFF
--- a/components/camel-esper/src/main/java/org/apacheextras/camel/component/esper/EsperEndpoint.java
+++ b/components/camel-esper/src/main/java/org/apacheextras/camel/component/esper/EsperEndpoint.java
@@ -49,6 +49,7 @@ public class EsperEndpoint extends DefaultEndpoint {
     private final EsperComponent component;
     private final String name;
     private boolean mapEvents;
+    private boolean mapBody = false;
     private boolean configured = false;
     private String pattern;
     private String eql;
@@ -198,4 +199,12 @@ public class EsperEndpoint extends DefaultEndpoint {
     public void setConfigured(boolean configured) {
         this.configured = configured;
     }
+
+	public boolean isMapBody() {
+		return mapBody;
+	}
+
+	public void setMapBody(boolean mapBody) {
+		this.mapBody = mapBody;
+	}
 }

--- a/components/camel-esper/src/main/java/org/apacheextras/camel/component/esper/EsperProducer.java
+++ b/components/camel-esper/src/main/java/org/apacheextras/camel/component/esper/EsperProducer.java
@@ -51,7 +51,9 @@ public class EsperProducer extends DefaultProducer {
     public void process(Exchange exchange) throws Exception {
         final Message in = exchange.getIn();
         final Object body = in.getBody();
-        if (endpoint.isMapEvents()) {
+        if (this.endpoint.isMapBody()) {
+        	getEsperRuntime().sendEvent((Map)body, this.endpoint.getName());
+        } else if (endpoint.isMapEvents()) {
             Map map = new HashMap(in.getHeaders());
             map.put("body", body);
             getEsperRuntime().sendEvent(map, endpoint.getName());

--- a/components/camel-esper/src/main/java/org/apacheextras/camel/component/esper/EsperProducer.java
+++ b/components/camel-esper/src/main/java/org/apacheextras/camel/component/esper/EsperProducer.java
@@ -46,19 +46,17 @@ public class EsperProducer extends DefaultProducer {
      * @param exchange
      * @throws Exception
      */
-    @SuppressWarnings("unchecked")
     @Override
     public void process(Exchange exchange) throws Exception {
         final Message in = exchange.getIn();
-        final Object body = in.getBody();
         if (this.endpoint.isMapBody()) {
-        	getEsperRuntime().sendEvent((Map)body, this.endpoint.getName());
+        	getEsperRuntime().sendEvent(in.getBody(Map.class), this.endpoint.getName());
         } else if (endpoint.isMapEvents()) {
-            Map map = new HashMap(in.getHeaders());
-            map.put("body", body);
+            Map<String, Object> map = new HashMap<String, Object>(in.getHeaders());
+            map.put("body", in.getBody());
             getEsperRuntime().sendEvent(map, endpoint.getName());
         } else {
-            getEsperRuntime().sendEvent(body);
+            getEsperRuntime().sendEvent(in.getBody());
         }
     }
 

--- a/components/camel-esper/src/test/java/org/apacheextras/camel/component/esper/EsperMapBodyTest.java
+++ b/components/camel-esper/src/test/java/org/apacheextras/camel/component/esper/EsperMapBodyTest.java
@@ -1,0 +1,67 @@
+/**************************************************************************************
+ https://camel-extra.github.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ 02110-1301, USA.
+
+ http://www.gnu.org/licenses/gpl-2.0-standalone.html
+ ***************************************************************************************/
+package org.apacheextras.camel.component.esper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Test;
+
+public class EsperMapBodyTest extends CamelTestSupport {
+
+	@Produce(uri = "direct://feed")
+	ProducerTemplate template;
+
+	@EndpointInject(uri = "mock:StockTickMock")
+	MockEndpoint mockEndpoint;
+
+	@Test
+	public void sendStockTickToLogTest() throws InterruptedException {
+		final Map<String, Object> stockTickMap = new HashMap<String, Object>();
+		stockTickMap.put("symbol", "GOOG");
+		stockTickMap.put("price", 1141.23);
+
+		mockEndpoint.expectedMessageCount(1);
+		template.sendBody(stockTickMap);
+
+		assertMockEndpointsSatisfied();
+	}
+
+	@Override
+	protected RouteBuilder createRouteBuilder() throws Exception {
+		return new RouteBuilder() {
+			@Override
+			public void configure() throws Exception {
+				from("direct://feed").to("esper://StockTickMap?mapBody=true");
+
+				from("esper://myEsperConsumer?configured=true&eql=select * from StockTickMap")
+						.to("mock://StockTickMock");
+			}
+		};
+	}
+}

--- a/components/camel-esper/src/test/resources/esper.cfg.xml
+++ b/components/camel-esper/src/test/resources/esper.cfg.xml
@@ -26,4 +26,10 @@
 
   <event-type name="StockTick" class="org.apacheextras.camel.component.esper.StockTick"/>
 
+  <event-type name="StockTickMap">
+	<java-util-map>
+		<map-property name="symbol" class="string"/>
+		<map-property name="price" class="double"/>
+    </java-util-map>
+  </event-type>
 </esper-configuration>


### PR DESCRIPTION
Added new feature to esper consumer.

According to oldest mapEvents param, now you can use mapBody param to add a map using endpoint name.

Example in my test file!
