### PR TITLE
Improve camel wmq component to allow bytebuffer as body

### DIFF
--- a/components/camel-wmq/pom.xml
+++ b/components/camel-wmq/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache-extras.camel-extra</groupId>
         <artifactId>components</artifactId>
-        <version>2.18.0-SNAPSHOT</version>
+        <version>2.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-wmq</artifactId>
@@ -74,7 +74,6 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
@@ -92,8 +91,23 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.9.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-parsers</artifactId>
+            <version>1.17</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
-
 
 </project>

--- a/components/camel-wmq/src/main/java/org/apacheextras/camel/component/wmq/WMQEndpoint.java
+++ b/components/camel-wmq/src/main/java/org/apacheextras/camel/component/wmq/WMQEndpoint.java
@@ -58,6 +58,17 @@ public class WMQEndpoint extends DefaultEndpoint {
     @UriParam
     private String queueManagerCCSID;
 
+    @UriParam
+    private String bodyType;
+
+    public WMQEndpoint() {
+    }
+
+    public WMQEndpoint(String uri, Component component, String destinationName) {
+        super(uri, component);
+        this.destinationName = destinationName;
+    }
+
     public String getDestinationName() {
         return destinationName;
     }
@@ -122,12 +133,13 @@ public class WMQEndpoint extends DefaultEndpoint {
         this.queueManagerCCSID = queueManagerCCSID;
     }
 
-    public WMQEndpoint() {
+
+    public void setBodyType(String bodyType) {
+        this.bodyType = bodyType;
     }
 
-    public WMQEndpoint(String uri, Component component, String destinationName) {
-        super(uri, component);
-        this.destinationName = destinationName;
+    public String getBodyType() {
+        return bodyType;
     }
 
     public Producer createProducer() throws Exception {
@@ -144,5 +156,4 @@ public class WMQEndpoint extends DefaultEndpoint {
     public boolean isSingleton() {
         return true;
     }
-
 }

--- a/components/camel-wmq/src/test/java/org/apacheextras/camel/component/wmq/WMQConsumerTest.java
+++ b/components/camel-wmq/src/test/java/org/apacheextras/camel/component/wmq/WMQConsumerTest.java
@@ -1,0 +1,106 @@
+package org.apacheextras.camel.component.wmq;
+
+import com.ibm.mq.MQGetMessageOptions;
+import com.ibm.mq.MQMessage;
+import com.ibm.mq.MQQueueManager;
+import com.ibm.mq.MQTopic;
+import com.ibm.mq.headers.MQHeaderList;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.tika.parser.txt.CharsetDetector;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WMQConsumerTest {
+
+    @Mock
+    private Exchange exchange;
+
+    @Mock
+    private Message message;
+
+    @Mock
+    private Processor processor;
+
+    @Mock
+    private WMQEndpoint wmqEndpoint;
+
+    @Mock
+    private WMQComponent wmqComponent;
+
+    @Mock
+    private MQQueueManager mqQueueManager;
+
+    @Mock
+    private MQTopic mqDestination;
+
+    @Mock
+    private Function<MQMessage, MQHeaderList> headerListFactory;
+
+    @Mock
+    private MQHeaderList mqHeaderList;
+
+    private WMQConsumer consumer;
+
+    @Captor
+    private ArgumentCaptor<Object> bodyCaptor;
+
+    @Captor
+    private ArgumentCaptor<Class<?>> bodyClassCaptor;
+
+    private static final String MESSAGE_IN_QUEUE = "I am the message";
+
+    @Before
+    public void before() throws Exception {
+        when(exchange.getIn()).thenReturn(this.message);
+        doReturn(exchange).when(this.wmqEndpoint).createExchange();
+        doReturn(wmqComponent).when(this.wmqEndpoint).getComponent();
+        doReturn("topic:test").when(this.wmqEndpoint).getDestinationName();
+        doReturn(mqQueueManager).when(wmqComponent).getQueueManager(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString());
+        doReturn(mqDestination).when(mqQueueManager).accessTopic(anyString(), anyString(), anyInt(), anyString(), anyString());
+        doReturn(mqHeaderList).when(headerListFactory).apply(any(MQMessage.class));
+        doReturn(-1).when(mqHeaderList).indexOf("MQRFH2");
+        doNothing().when(this.message).setBody(bodyCaptor.capture(), bodyClassCaptor.capture());
+        doAnswer((arg) -> {
+            final MQMessage mqMessage = (MQMessage) arg.getArguments()[0];
+            mqMessage.write(MESSAGE_IN_QUEUE.getBytes());
+            return null;
+        }).when(mqDestination).get(any(MQMessage.class), any(MQGetMessageOptions.class));
+        this.consumer = new WMQConsumer(this.wmqEndpoint, this.processor, this.headerListFactory);
+    }
+
+    @Test
+    public void pool_noOutputConfiguration_setBodyAsUTF8String() throws Exception {
+        this.consumer.poll();
+        final String value = (String) bodyCaptor.getValue();
+        CharsetDetector charsetDetector = new CharsetDetector();
+        charsetDetector.setText(value.getBytes());
+        assertThat(charsetDetector.detect().getName()).isEqualTo("UTF-8");
+    }
+
+    @Test
+    public void pool_bodyTypeAsBytes_setBodyAsByteBuffer() throws Exception {
+        when(wmqEndpoint.getBodyType()).thenReturn("bytes");
+        this.consumer.poll();
+
+        assertThat(bodyCaptor.getValue()).isInstanceOf(ByteBuffer.class);
+        assertThat(bodyClassCaptor.getValue()).isEqualTo(ByteBuffer.class);
+    }
+
+
+}


### PR DESCRIPTION
For our internal development, we need to improve WMQConsumer :
Today it only allow to use String as body output but we need to add simple bytebuffer too.