### PR TITLE
Update to camel 2.22 + Fix test and compile errors

### DIFF
--- a/components/camel-esper/pom.xml
+++ b/components/camel-esper/pom.xml
@@ -26,7 +26,7 @@
   <parent>
       <groupId>org.apache-extras.camel-extra</groupId>
       <artifactId>components</artifactId>
-      <version>2.19-SNAPSHOT</version>
+      <version>2.22-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-esper</artifactId>

--- a/components/camel-esper/src/main/java/org/apacheextras/camel/component/esper/EsperEndpoint.java
+++ b/components/camel-esper/src/main/java/org/apacheextras/camel/component/esper/EsperEndpoint.java
@@ -121,7 +121,7 @@ public class EsperEndpoint extends DefaultEndpoint {
      */
     public Exchange createExchange(EventBean newEventBean, EventBean oldEventBean, EPStatement statement) {
         Exchange exchange = createExchange(ExchangePattern.InOnly);
-        Message in = new EsperMessage(newEventBean, oldEventBean);
+        Message in = new EsperMessage(getCamelContext(), newEventBean, oldEventBean);
         in.setHeader("CamelEsperName", name);
         in.setHeader("CamelEsperStatement", statement);
         if (pattern != null) {

--- a/components/camel-esper/src/main/java/org/apacheextras/camel/component/esper/EsperMessage.java
+++ b/components/camel-esper/src/main/java/org/apacheextras/camel/component/esper/EsperMessage.java
@@ -23,6 +23,7 @@
 package org.apacheextras.camel.component.esper;
 
 import com.espertech.esper.client.EventBean;
+import org.apache.camel.CamelContext;
 import org.apache.camel.impl.DefaultMessage;
 
 /**
@@ -37,10 +38,12 @@ public class EsperMessage extends DefaultMessage {
     /**
      * Creates a new instance of an EsperMessage.
      *
+     * @param camelContext CamelContext
      * @param newEvent EventBean
      * @param oldEvent EventBean
      */
-    public EsperMessage(EventBean newEvent, EventBean oldEvent) {
+    public EsperMessage(CamelContext camelContext, EventBean newEvent, EventBean oldEvent) {
+        super(camelContext);
         this.newEvent = newEvent;
         this.oldEvent = oldEvent;
         // use new event as the default body
@@ -72,6 +75,6 @@ public class EsperMessage extends DefaultMessage {
      */
     @Override
     public DefaultMessage newInstance() {
-        return new EsperMessage(newEvent, oldEvent);
+        return new EsperMessage(getCamelContext(), newEvent, oldEvent);
     }
 }

--- a/components/camel-exist/pom.xml
+++ b/components/camel-exist/pom.xml
@@ -26,7 +26,7 @@
   <parent>
       <groupId>org.apache-extras.camel-extra</groupId>
       <artifactId>components</artifactId>
-      <version>2.19-SNAPSHOT</version>
+      <version>2.22-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-exist</artifactId>

--- a/components/camel-firebase/pom.xml
+++ b/components/camel-firebase/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache-extras.camel-extra</groupId>
         <artifactId>components</artifactId>
-        <version>2.19-SNAPSHOT</version>
+        <version>2.22-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/camel-hibernate/pom.xml
+++ b/components/camel-hibernate/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>components</artifactId>
-    <version>2.19-SNAPSHOT</version>
+    <version>2.22-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-hibernate</artifactId>

--- a/components/camel-hibernate/src/test/java/org/apacheextras/camel/component/hibernate/QueryBuilderHibernateTest.java
+++ b/components/camel-hibernate/src/test/java/org/apacheextras/camel/component/hibernate/QueryBuilderHibernateTest.java
@@ -27,10 +27,10 @@ import org.apacheextras.camel.examples.SendEmail;
 import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
 import org.hibernate.service.ServiceRegistry;
-import org.hibernate.service.ServiceRegistryBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,11 +49,11 @@ public class QueryBuilderHibernateTest {
     // Fixture setup
 
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
         Configuration configuration = new Configuration().setProperty(Environment.DIALECT, "org.hibernate.dialect.DerbyDialect")
             .setProperty(Environment.URL, "jdbc:derby:target/testdb;create=true").setProperty(Environment.USER, "").setProperty(Environment.PASS, "")
             .setProperty(Environment.HBM2DDL_AUTO, "create").addResource("org/apacheextras/camel/examples/SendEmail.hbm.xml");
-        ServiceRegistry serviceRegistry = new ServiceRegistryBuilder().applySettings(configuration.getProperties()).buildServiceRegistry();
+        ServiceRegistry serviceRegistry = new StandardServiceRegistryBuilder().applySettings(configuration.getProperties()).build();
         SessionFactory sessionFactory = configuration.buildSessionFactory(serviceRegistry);
         session = sessionFactory.openSession();
 
@@ -61,7 +61,7 @@ public class QueryBuilderHibernateTest {
     }
 
     @After
-    public void tearDown() {
+    public void tearDown() throws Exception {
         session.close();
     }
 

--- a/components/camel-hibernate/src/test/resources/org/apacheextras/camel/component/hibernate/HibernateSpringTest-context.xml
+++ b/components/camel-hibernate/src/test/resources/org/apacheextras/camel/component/hibernate/HibernateSpringTest-context.xml
@@ -48,7 +48,7 @@
         <constructor-arg ref="transactionTemplate"/>
     </bean>
 
-  <bean id="sessionFactory" class="org.springframework.orm.hibernate4.LocalSessionFactoryBean">
+  <bean id="sessionFactory" class="org.springframework.orm.hibernate5.LocalSessionFactoryBean">
     <property name="dataSource" ref="dataSource"/>
     <property name="mappingResources">
       <list>
@@ -65,7 +65,7 @@
 
   <jdbc:embedded-database id="dataSource" type="DERBY" />
 
-  <bean id="transactionManager" class="org.springframework.orm.hibernate4.HibernateTransactionManager">
+  <bean id="transactionManager" class="org.springframework.orm.hibernate5.HibernateTransactionManager">
     <property name="sessionFactory" ref="sessionFactory"/>
   </bean>
 

--- a/components/camel-jboss/pom.xml
+++ b/components/camel-jboss/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache-extras.camel-extra</groupId>
         <artifactId>components</artifactId>
-        <version>2.19-SNAPSHOT</version>
+        <version>2.22-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-jboss</artifactId>

--- a/components/camel-jboss6/pom.xml
+++ b/components/camel-jboss6/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache-extras.camel-extra</groupId>
         <artifactId>components</artifactId>
-        <version>2.19-SNAPSHOT</version>
+        <version>2.22-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-jboss6</artifactId>

--- a/components/camel-jcifs/pom.xml
+++ b/components/camel-jcifs/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache-extras.camel-extra</groupId>
         <artifactId>components</artifactId>
-      <version>2.19-SNAPSHOT</version>
+      <version>2.22-SNAPSHOT</version>
     </parent>
 
    <artifactId>camel-jcifs</artifactId>

--- a/components/camel-jcifs/src/main/java/org/apacheextras/camel/component/jcifs/SmbConsumer.java
+++ b/components/camel-jcifs/src/main/java/org/apacheextras/camel/component/jcifs/SmbConsumer.java
@@ -33,6 +33,7 @@ import org.apache.camel.component.file.GenericFile;
 import org.apache.camel.component.file.GenericFileConsumer;
 import org.apache.camel.component.file.GenericFileEndpoint;
 import org.apache.camel.component.file.GenericFileOperations;
+import org.apache.camel.component.file.GenericFileProcessStrategy;
 import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.ObjectHelper;
 
@@ -41,8 +42,8 @@ public class SmbConsumer extends GenericFileConsumer<SmbFile> {
     private String endpointPath;
     private String currentRelativePath = "";
 
-    public SmbConsumer(GenericFileEndpoint<SmbFile> endpoint, Processor processor, GenericFileOperations<SmbFile> operations) {
-        super(endpoint, processor, operations);
+    public SmbConsumer(GenericFileEndpoint<SmbFile> endpoint, Processor processor, GenericFileOperations<SmbFile> operations, GenericFileProcessStrategy<SmbFile> strategy) {
+        super(endpoint, processor, operations, strategy);
         this.endpointPath = endpoint.getConfiguration().getDirectory();
     }
 

--- a/components/camel-jcifs/src/main/java/org/apacheextras/camel/component/jcifs/SmbEndpoint.java
+++ b/components/camel-jcifs/src/main/java/org/apacheextras/camel/component/jcifs/SmbEndpoint.java
@@ -48,7 +48,7 @@ public class SmbEndpoint extends GenericFileEndpoint<SmbFile> {
 
     @Override
     public SmbConsumer createConsumer(Processor processor) throws Exception {
-        SmbConsumer consumer = new SmbConsumer(this, processor, createSmbOperations());
+        SmbConsumer consumer = new SmbConsumer(this, processor, createSmbOperations(), processStrategy != null ? processStrategy : createGenericFileStrategy());
 
         if (isDelete() && getMove() != null) {
             throw new IllegalArgumentException("You cannot set both delete=true and move options");

--- a/components/camel-jcifs/src/main/java/org/apacheextras/camel/component/jcifs/SmbOperations.java
+++ b/components/camel-jcifs/src/main/java/org/apacheextras/camel/component/jcifs/SmbOperations.java
@@ -106,7 +106,7 @@ public class SmbOperations<SmbFile> implements GenericFileOperations<SmbFile> {
     }
 
     @Override
-    public boolean retrieveFile(String name, Exchange exchange) {
+    public boolean retrieveFile(String name, Exchange exchange, long size) {
         if (ObjectHelper.isNotEmpty(endpoint.getLocalWorkDirectory())) {
             return retrieveFileToFileInLocalWorkDirectory(name, exchange);
         }
@@ -258,7 +258,7 @@ public class SmbOperations<SmbFile> implements GenericFileOperations<SmbFile> {
     }
 
     @Override
-    public boolean storeFile(String name, Exchange exchange) {
+    public boolean storeFile(String name, Exchange exchange, long size){
         boolean append = false;
         // if an existing file already exists what should we do?
         if (existsFile(name)) {
@@ -374,7 +374,7 @@ public class SmbOperations<SmbFile> implements GenericFileOperations<SmbFile> {
     }
 
     @Override
-    public void releaseRetreivedFileResources(Exchange exchange) {
+    public void releaseRetrievedFileResources(Exchange exchange) {
         // Right now do nothing
     }
 }

--- a/components/camel-jcifs/src/main/java/org/apacheextras/camel/component/jcifs/SmbProducer.java
+++ b/components/camel-jcifs/src/main/java/org/apacheextras/camel/component/jcifs/SmbProducer.java
@@ -268,7 +268,7 @@ public class SmbProducer extends GenericFileProducer<SmbFile> implements Service
             log.debug("About to write [" + fileName + "] to [" + getEndpoint() + "] from exchange [" + exchange + "]");
         }
 
-        boolean success = operations.storeFile(fileName, exchange);
+        boolean success = operations.storeFile(fileName, exchange, -1);
         if (!success) {
             throw new GenericFileOperationFailedException("Error writing file [" + fileName + "]");
         }

--- a/components/camel-jcifs/src/test/java/org/apacheextras/camel/component/jcifs/FromSmbChangedReadLockZeroLengthTest.java
+++ b/components/camel-jcifs/src/test/java/org/apacheextras/camel/component/jcifs/FromSmbChangedReadLockZeroLengthTest.java
@@ -89,7 +89,6 @@ public class FromSmbChangedReadLockZeroLengthTest extends BaseSmbTestSupport {
                 return FILE_CONTENT.length;
             }
         });
-        expect(mockInputStream.read((byte[]) anyObject())).andReturn(-1);
         mockInputStream.close();
 
         smbApiFactory.putSmbFiles(getSmbBaseUrl() + "/", rootDir);

--- a/components/camel-rcode/pom.xml
+++ b/components/camel-rcode/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>components</artifactId>
-    <version>2.19-SNAPSHOT</version>
+    <version>2.22-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-rcode</artifactId>

--- a/components/camel-spring-neo4j/pom.xml
+++ b/components/camel-spring-neo4j/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>components</artifactId>
-    <version>2.19-SNAPSHOT</version>
+    <version>2.22-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-spring-neo4j</artifactId>

--- a/components/camel-virtualbox/pom.xml
+++ b/components/camel-virtualbox/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>components</artifactId>
-    <version>2.19-SNAPSHOT</version>
+    <version>2.22-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-virtualbox</artifactId>

--- a/components/camel-vtdxml/pom.xml
+++ b/components/camel-vtdxml/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>components</artifactId>
-    <version>2.19-SNAPSHOT</version>
+    <version>2.22-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-vtdxml</artifactId>

--- a/components/camel-vtdxml/src/main/java/org/apacheextras/camel/component/vtdxml/VtdXmlXPathBuilder.java
+++ b/components/camel-vtdxml/src/main/java/org/apacheextras/camel/component/vtdxml/VtdXmlXPathBuilder.java
@@ -204,6 +204,11 @@ public class VtdXmlXPathBuilder implements Expression, Predicate, NamespaceAware
         ap.selectXPath(text);
     }
 
+    @Override
+    public Map<String, String> getNamespaces() {
+        return namespaces;
+    }
+
     /**
      * Iterator to be used for XPath expressions
      */

--- a/components/camel-wmq/pom.xml
+++ b/components/camel-wmq/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache-extras.camel-extra</groupId>
         <artifactId>components</artifactId>
-        <version>2.19-SNAPSHOT</version>
+        <version>2.22-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-wmq</artifactId>

--- a/components/camel-zeromq/pom.xml
+++ b/components/camel-zeromq/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>components</artifactId>
-    <version>2.19-SNAPSHOT</version>
+    <version>2.22-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-zeromq</artifactId>

--- a/components/camel-zeromq/src/main/java/org/apacheextras/camel/component/zeromq/ZeromqEndpoint.java
+++ b/components/camel-zeromq/src/main/java/org/apacheextras/camel/component/zeromq/ZeromqEndpoint.java
@@ -101,7 +101,7 @@ public class ZeromqEndpoint extends DefaultEndpoint {
     Exchange createZeromqExchange(byte[] body) {
         Exchange exchange = new DefaultExchange(getCamelContext(), getExchangePattern());
 
-        Message message = new DefaultMessage();
+        Message message = new DefaultMessage(getCamelContext());
         message.setHeader(ZeromqConstants.HEADER_SOURCE, getSocketAddress());
         message.setHeader(ZeromqConstants.HEADER_SOCKET_TYPE, socketType);
         message.setHeader(ZeromqConstants.HEADER_TIMESTAMP, System.currentTimeMillis());

--- a/components/camel-zeromq/src/test/java/org/apacheextras/camel/component/zeromq/ZeromqEndpointTest.java
+++ b/components/camel-zeromq/src/test/java/org/apacheextras/camel/component/zeromq/ZeromqEndpointTest.java
@@ -22,9 +22,12 @@
 package org.apacheextras.camel.component.zeromq;
 
 import java.net.URISyntaxException;
+import java.util.HashMap;
+import org.apache.camel.CamelContext;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
+import org.apache.camel.spi.HeadersMapFactory;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,11 +35,20 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import org.mockito.Mock;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 public class ZeromqEndpointTest {
 
     private ZeromqEndpoint endpoint;
+    
+    @Mock
+    private CamelContext context;
+    
+    @Mock
+    private HeadersMapFactory headersMapFactory;
 
     @Test
     public void assertSingleton() throws URISyntaxException {
@@ -45,7 +57,13 @@ public class ZeromqEndpointTest {
 
     @Before
     public void before() throws URISyntaxException {
+        initMocks(this);
+        
         endpoint = new ZeromqEndpoint("zeromq:tcp://localhost:1234?socketType=PUBLISH", "tcp://localhost:1234?socketType=PUBLISH", new ZeromqComponent());
+        endpoint.setCamelContext(context);
+        
+        when(context.getHeadersMapFactory()).thenReturn(headersMapFactory);
+        when(headersMapFactory.newMap()).thenAnswer((invocation) -> new HashMap<>());
     }
 
     @Test

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>camel-parent</artifactId>
-    <version>2.19-SNAPSHOT</version>
+    <version>2.22-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/examples/camel-example-esper/pom.xml
+++ b/examples/camel-example-esper/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>examples</artifactId>
-    <version>2.19-SNAPSHOT</version>
+    <version>2.22-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-esper-demo</artifactId>

--- a/examples/camel-example-hibernate/pom.xml
+++ b/examples/camel-example-hibernate/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>examples</artifactId>
-    <version>2.19-SNAPSHOT</version>
+    <version>2.22-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-example-hibernate</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -26,7 +26,7 @@
   <parent>
       <groupId>org.apache-extras.camel-extra</groupId>
       <artifactId>camel-parent</artifactId>
-      <version>2.19-SNAPSHOT</version>
+      <version>2.22-SNAPSHOT</version>
       <relativePath>..</relativePath>
   </parent>
 

--- a/platform/karaf/features/pom.xml
+++ b/platform/karaf/features/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>features</artifactId>
-    <version>2.19-SNAPSHOT</version>
+    <version>2.22-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache-extras.camel-extra.karaf</groupId>

--- a/platform/karaf/features/src/main/resources/features.xml
+++ b/platform/karaf/features/src/main/resources/features.xml
@@ -46,7 +46,7 @@
     <feature version='${camel-version}'>camel-spring</feature>
     <bundle>mvn:org.apache-extras.camel-extra/camel-hibernate/${project.version}</bundle>
     <bundle start-level="30">mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/${geronimo-jta-spec-version}</bundle>
-    <bundle start-level="30">mvn:org.apache.geronimo.specs/geronimo-jpa_2.0_spec/${geronimo-jpa2-spec-version}</bundle>
+    <bundle start-level="30">mvn:org.apache.geronimo.specs/geronimo-jpa_2.1_spec/${geronimo-jpa-spec-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.antlr/${antlr-bundle-hibernate-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jsr303-api-1.0.0/${jsr303-bundle-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.dom4j/${dom4j-bundle-version}</bundle>
@@ -55,7 +55,6 @@
     <bundle dependency='true'>mvn:com.fasterxml/classmate/${classmate-version}</bundle>
     <bundle dependency='true'>mvn:org.jboss.logging/jboss-logging/${jboss-logging-version}</bundle>
     <bundle dependency='true'>mvn:org.hibernate/hibernate-core/${hibernate-version}</bundle>
-    <bundle dependency='true'>mvn:org.hibernate/hibernate-entitymanager/${hibernate-version}</bundle>
     <bundle dependency='true'>mvn:org.hibernate/hibernate-osgi/${hibernate-version}</bundle>
     <bundle dependency='true'>mvn:org.javassist/javassist/${javassist-version}</bundle>
   </feature>

--- a/platform/karaf/pom.xml
+++ b/platform/karaf/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>platform</artifactId>
-    <version>2.19-SNAPSHOT</version>
+    <version>2.22-SNAPSHOT</version>
   </parent>
 
   <artifactId>features</artifactId>

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>camel-parent</artifactId>
-    <version>2.19-SNAPSHOT</version>
+    <version>2.22-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,12 +27,12 @@
   <parent>
     <groupId>org.apache.camel</groupId>
     <artifactId>camel-parent</artifactId>
-    <version>2.18.0</version>
+    <version>2.22.0</version>
   </parent>
 
   <groupId>org.apache-extras.camel-extra</groupId>
   <artifactId>camel-parent</artifactId>
-  <version>2.19-SNAPSHOT</version>
+  <version>2.22-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Camel Extra</name>
   <description>Camel Extra Parent POM</description>
@@ -54,7 +54,7 @@
   </prerequisites>
 
   <properties>
-    <camel-version>2.18.0</camel-version>
+    <camel-version>2.22.0</camel-version>
 
     <site-repo-url>scpexe://people.apache.org/www/activemq.apache.org/camel/maven/</site-repo-url>
     <sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/
@@ -76,15 +76,17 @@
     <akka-version>2.3.11</akka-version>
     <antlr-bundle-version>4.5</antlr-bundle-version>
     <antlr-bundle-hibernate-version>2.7.7_5</antlr-bundle-hibernate-version>
+    <classmate-version>1.3.0</classmate-version>
     <cobertura-maven-plugin-version>2.6</cobertura-maven-plugin-version>
     <db4o-version>8.0</db4o-version>
+    <easymock-version>3.2</easymock-version>
     <esper-version>5.2.0</esper-version>
     <exist-version>0.9.2</exist-version>
     <geronimo-servlet-spec12-version>1.2</geronimo-servlet-spec12-version>
-    <hibernate-commons-annotation-version>4.0.2.Final</hibernate-commons-annotation-version>
-    <jandex-version>1.1.0.Final</jandex-version>
+    <hibernate-commons-annotation-version>5.0.1.Final</hibernate-commons-annotation-version>
+    <jandex-version>2.0.3.Final</jandex-version>
     <javax-validation-api-version>1.1.0.Final</javax-validation-api-version>
-    <javassist-version>3.18.1-GA</javassist-version>
+    <javassist-version>3.22.0-GA</javassist-version>
     <jaxws-rt-version>2.2.9-b14002</jaxws-rt-version>
     <jsr303-bundle-version>2.2.0</jsr303-bundle-version>
     <jboss-vfs5-version>2.2.3.GA</jboss-vfs5-version>
@@ -273,6 +275,11 @@
         <artifactId>spring-test</artifactId>
         <version>${spring-version}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.easymock</groupId>
+        <artifactId>easymock</artifactId>
+        <version>${easymock-version}</version>
       </dependency>
       <dependency>
         <groupId>org.easymock</groupId>

--- a/tests/camel-extra-itest-karaf/pom.xml
+++ b/tests/camel-extra-itest-karaf/pom.xml
@@ -26,7 +26,7 @@ http://www.gnu.org/licenses/gpl-2.0-standalone.html
   <parent>
     <artifactId>tests</artifactId>
     <groupId>org.apache-extras.camel-extra</groupId>
-    <version>2.18.0-SNAPSHOT</version>
+    <version>2.22-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -26,7 +26,7 @@ http://www.gnu.org/licenses/gpl-2.0-standalone.html
   <parent>
     <artifactId>camel-parent</artifactId>
     <groupId>org.apache-extras.camel-extra</groupId>
-    <version>2.18.0-SNAPSHOT</version>
+    <version>2.22-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
I've noticed that the camel-extra project is lagging behind the Camel core project. The latest camel-extra release is aligned with Camel 2.18.0 whereas the camel-core project is already at 2.22.0.

Some of the components in extra no longer work with Camel 2.22.0 due to breaking changes in the Camel API's. For example, the JCIFS component no longer works due to changes in the GenericFileConsumer class. I get the following stack trace when trying to use it:
```
Caused by: java.lang.NoSuchMethodError: org.apache.camel.component.file.GenericFileConsumer.<init>(Lorg/apache/camel/component/file/GenericFileEndpoint;Lorg/apache/camel/Processor;Lorg/apache/camel/component/file/GenericFileOperations;)V
    at org.apacheextras.camel.component.jcifs.SmbConsumer.<init> (SmbConsumer.java:45)
    at org.apacheextras.camel.component.jcifs.SmbEndpoint.createConsumer (SmbEndpoint.java:51)
    at org.apacheextras.camel.component.jcifs.SmbEndpoint.createConsumer (SmbEndpoint.java:34)
```

On the camel-extra mailing list someone has reported the same problem here: http://camel-extra.1091541.n5.nabble.com/Camel-JCIFS-Component-not-working-with-camel-core-2-22-0-td512.html

This pull request updates the Camel dependencies to version 2.22.0 and fixes all compilation and test errors (see commit message for more details).

From the Camel mailing list I had gathered that the project was no longer being released due to failing integration tests in the Apache Karaf container. I also had a look at those and all tests are green now when running `mvn clean install -Pintegration`.

Could someone review my changes, merge this pull request and provision a new release?