### PR TITLE
Fix bug in "fileExist=Ignore" option of camel-jcifs

### DIFF
--- a/components/camel-jcifs/src/main/java/org/apacheextras/camel/component/jcifs/DefaultSmbClient.java
+++ b/components/camel-jcifs/src/main/java/org/apacheextras/camel/component/jcifs/DefaultSmbClient.java
@@ -107,8 +107,8 @@ public class DefaultSmbClient implements SmbClient {
       }
     } catch (IOException e) {
       LOGGER.error(
-          "Could not locate or create direction '{}' due to '{}'",
-          url, e);
+          "Could not locate or create directory '{}' due to '{}'",
+          url, e.getMessage(), e);
       return false;
     }
     return true;
@@ -194,7 +194,7 @@ public class DefaultSmbClient implements SmbClient {
         }
       }
     } catch (SmbException e) {
-      LOGGER.error("Could not delete '{}' due to '{}'", url, e);
+      LOGGER.error("Could not delete '{}' due to '{}'", url, e.getMessage(), e);
       return false;
     }
     return true;
@@ -214,7 +214,7 @@ public class DefaultSmbClient implements SmbClient {
         sFile.renameTo(renamedFile);
       }
     } catch (SmbException e) {
-      LOGGER.error("Could not rename '{}' to '{}' due to '{}'", new Object[]{ fromUrl, toUrl, e});
+      LOGGER.error("Could not rename '{}' to '{}' due to '{}'", new Object[]{ fromUrl, toUrl, e.getMessage(), e});
       return false;
     }
     return true;

--- a/components/camel-jcifs/src/main/java/org/apacheextras/camel/component/jcifs/SmbOperations.java
+++ b/components/camel-jcifs/src/main/java/org/apacheextras/camel/component/jcifs/SmbOperations.java
@@ -267,7 +267,7 @@ public class SmbOperations<SmbFile> implements GenericFileOperations<SmbFile> {
                 if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug("An existing file already exists: " + name + ". Ignore and do not override it.");
                 }
-                return false;
+                return true;
             } else if (endpoint.getFileExist() == GenericFileExist.Fail) {
                 throw new GenericFileOperationFailedException("File already exist: " + name + ". Cannot write new file.");
             } else if (endpoint.getFileExist() == GenericFileExist.Move) {

--- a/components/camel-jcifs/src/test/java/org/apacheextras/camel/component/jcifs/FromFileToSmbIgnoreExistingFileTest.java
+++ b/components/camel-jcifs/src/test/java/org/apacheextras/camel/component/jcifs/FromFileToSmbIgnoreExistingFileTest.java
@@ -1,0 +1,111 @@
+/**************************************************************************************
+ https://camel-extra.github.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation; either version 3
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ 02110-1301, USA.
+
+ http://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ ***************************************************************************************/
+package org.apacheextras.camel.component.jcifs;
+
+import jcifs.smb.SmbFile;
+import jcifs.smb.SmbFileOutputStream;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import static org.easymock.EasyMock.anyObject;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.createStrictMock;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.createStrictMock;
+import static org.easymock.EasyMock.eq;
+
+/**
+ * Unit test to verify that the fileExist=Ignore option does not delete the existing
+ * file and that it continues routing the exchange to the next endpoint without
+ * throwing an exception.
+ */
+public class FromFileToSmbIgnoreExistingFileTest extends BaseSmbTestSupport {
+
+    SmbFile rootDir;
+    SmbFile logoOne;
+    SmbFile logoTwo;
+    SmbFileOutputStream mockOutputStream;
+
+    protected String getSmbBaseUrl() {
+        return "smb://localhost/" + getShare() + "/camel/" + getClass().getSimpleName();
+    }
+
+    private String getSmbUrl() {
+        return "smb://" + getDomain() + ";" + getUsername() + "@localhost/" + getShare() + "/camel/" + getClass().getSimpleName() + "?password=" + getPassword()
+               + "&fileExist=Ignore";
+    }
+
+    @Before
+    public void setUpFileSystem() throws Exception {
+        logoOne = createStrictMock(SmbFile.class);
+        logoTwo = createStrictMock(SmbFile.class);
+        rootDir = createStrictMock(SmbFile.class);
+        mockOutputStream = createMock(SmbFileOutputStream.class);
+
+        expect(rootDir.exists()).andReturn(true).times(2);
+        
+        //Logo one already exists so we expect that one NOT to be written!
+        expect(logoOne.exists()).andReturn(true).times(1);
+        
+        //Log two doesn't exist so we expect the file to be written as usual
+        expect(logoTwo.exists()).andReturn(false).times(1);
+        expect(logoTwo.getName()).andReturn("logo2.png").times(1);
+        mockOutputStream.write((byte[])anyObject(), eq(0), eq(15358));
+        mockOutputStream.close();
+
+        smbApiFactory.putSmbFiles(getSmbBaseUrl(), rootDir);
+        smbApiFactory.putSmbFiles(getSmbBaseUrl() + "/logo1.png", logoOne);
+        smbApiFactory.putSmbFiles(getSmbBaseUrl() + "/logo2.png", logoTwo);
+        smbApiFactory.putSmbFileOutputStream("logo2.png", mockOutputStream);
+
+    };
+
+    @Test
+    public void testFromFileToSmbIgnoreExistingFile() throws Exception {
+        replay(rootDir, logoOne, logoTwo, mockOutputStream);
+
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        //Important: Both exchanges should reach the final endpoint even though one file was ignored because it already existed
+        mock.expectedMessageCount(2);
+
+        assertMockEndpointsSatisfied();
+
+        verify(rootDir, logoOne, logoTwo, mockOutputStream);
+    }
+
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            public void configure() throws Exception {
+                from("file:src/test/data?noop=true&consumer.delay=3000").to(getSmbUrl()).to("mock:result");
+            }
+        };
+    }
+}


### PR DESCRIPTION
The "fileExist=Ignore" option of the camel-jcifs does not work as expected. Instead of silently ignoring a file that already exists it throws an exception causing the exchange that is being routed to fail. This is not how it is intended to work because there is already the "Fail" option to achieve that. I compared this behaviour to the other Camel file components (File, FTP, SFTP, ...) and they do not behave this way.

The fix was really simple (switching a boolean from false to true - indicating the file was processed successfully). I also added an integration test to verify that it now behaves correctly.

A second problem I noticed is that the errors in the log were not correctly formatted. The last parameter in the log message was not being substituted correctly. After some searching I found that this is due to a change in SLF4J version 1.6.0 which treats parameters of type exception differently. I fixed this and all similar usages in the camel-jcifs library.