### PR TITLE
doc: Add camel-jcifs to README list

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The current extra components list is:
 * camel-exist
 * camel-firebase
 * camel-hibernate
+* camel-jcifs
 * camel-rcode
 * camel-virtualbox
 * camel-vtdxml


### PR DESCRIPTION
JCIFS just got added in #39 but the bulleted list in the main README needs the addition as well. Thanks!