### PR TITLE
Upgrade to Camel 3.20.2

### DIFF
--- a/components/camel-wmq/pom.xml
+++ b/components/camel-wmq/pom.xml
@@ -18,13 +18,13 @@
 
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>camel-wmq</artifactId>
-    <version>3.14.3-SNAPSHOT</version>
+    <version>3.20.2-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>Camel Extra :: IBM Websphere MQ</name>
     <description>Camel IBM Websphere MQ component</description>
 
     <properties>
-        <camel-version>3.14.3</camel-version>
+        <camel-version>3.20.2</camel-version>
     </properties>
 
     <url>https://camel-extra.github.io</url>


### PR DESCRIPTION
## Motivation

The latest LTS version of Apache Camel is 3.20, let's upgrade the component `camel-wmq` to that version.

## Modifications:

* Update the version of the component
* Update the version of Apache Camel