### PR TITLE
Upgrade to Camel 3.20.6

### DIFF
--- a/components/camel-wmq/pom.xml
+++ b/components/camel-wmq/pom.xml
@@ -18,13 +18,13 @@
 
     <groupId>org.apache-extras.camel-extra</groupId>
     <artifactId>camel-wmq</artifactId>
-    <version>3.20.3-SNAPSHOT</version>
+    <version>3.20.6-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>Camel Extra :: IBM Websphere MQ</name>
     <description>Camel IBM Websphere MQ component</description>
 
     <properties>
-        <camel-version>3.20.2</camel-version>
+        <camel-version>3.20.6</camel-version>
     </properties>
 
     <url>https://camel-extra.github.io</url>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>com.ibm.mq</groupId>
             <artifactId>com.ibm.mq.allclient</artifactId>
-            <version>9.2.2.0</version>
+            <version>9.3.2.1</version>
         </dependency>
 
         <!-- camel -->
@@ -100,8 +100,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Motivation

A new maintenance version of Camel 3.20 has been released with many bug fixes and CVEs fixed 

## Modifications:

* Update the version of the component
* Update the version of Apache Camel
* Set the Java version to 11 as it is the minimal version for Camel 3.20
* Upgrade the version of `com.ibm.mq.allclient` to the latest version compatible with Camel 3.20 to depend on a more recent version of `org.json:json` that doesn't have known CVEs